### PR TITLE
Generalize skills by removing project-specific references

### DIFF
--- a/i18n-standards/SKILL.md
+++ b/i18n-standards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: i18n-standards
-description: Standards for internationalization and string handling. Apply when touching files with user-facing strings, resolving mixed Dutch/English text, or preparing strings for translation.
+description: Standards for internationalization and string handling. Apply when touching files with user-facing strings or preparing strings for translation.
 allowed-tools: Read, Grep, Glob, Edit
 ---
 
@@ -10,33 +10,33 @@ Apply these standards when working with user-facing strings in this project.
 
 ## Background
 
-This codebase has mixed Dutch and English strings due to incremental development.
-This is a low-priority cleanup task - apply these standards gradually when you touch
+Projects often accumulate a mix of hardcoded and translatable strings over time.
+This is a low-priority cleanup task — apply these standards gradually when you touch
 files that contain user-facing strings.
 
 ## Quick Reference
 
-### User-Facing Strings
+### PHP: User-Facing Strings (WordPress)
 
-All user-facing strings should use WordPress translation functions:
+All user-facing strings should use WordPress translation functions with the project's text domain constant:
 
 ```php
 // Simple string
-echo __('Save Changes', THEME_TEXT_DOMAIN);
+echo __('Save Changes', TEXT_DOMAIN);
 
 // Echoing directly
-_e('Submit Form', THEME_TEXT_DOMAIN);
+_e('Submit Form', TEXT_DOMAIN);
 
 // With placeholders
 printf(
-    __('Showing %d of %d results', THEME_TEXT_DOMAIN),
+    __('Showing %d of %d results', TEXT_DOMAIN),
     $current,
     $total
 );
 
 // Pluralization
 printf(
-    _n('%d item', '%d items', $count, THEME_TEXT_DOMAIN),
+    _n('%d item', '%d items', $count, TEXT_DOMAIN),
     $count
 );
 ```
@@ -46,31 +46,31 @@ printf(
 | Context | Language | Example |
 |---------|----------|---------|
 | Code comments | English | `// Check if user is logged in` |
-| Variable/function names | English | `$patient_name`, `get_opening_hours()` |
+| Variable/function names | English | `$user_name`, `get_opening_hours()` |
 | Log messages | English | `error_log('Failed to load template');` |
-| User-facing text | Dutch (translatable) | `__('Instellingen', THEME_TEXT_DOMAIN)` |
-| Admin labels | Dutch (translatable) | `'label' => __('Telefoonnummer', THEME_TEXT_DOMAIN)` |
+| User-facing text | Primary locale (translatable) | `__('Settings', TEXT_DOMAIN)` |
+| Admin labels | Primary locale (translatable) | `'label' => __('Phone number', TEXT_DOMAIN)` |
 
-### JavaScript Strings
+### JavaScript Strings (WordPress)
 
 Use `@wordpress/i18n` for Gutenberg/block editor strings:
 
 ```javascript
 import { __, _n, sprintf } from '@wordpress/i18n';
 
-// Simple string
-const label = __('Edit', 'nok-2025-v1');
+// Simple string — use the text domain string (not the PHP constant)
+const label = __('Edit', 'my-theme');
 
 // With placeholders
 const message = sprintf(
-    __('Showing %d results', 'nok-2025-v1'),
+    __('Showing %d results', 'my-theme'),
     count
 );
 ```
 
 ## When Refactoring
 
-When you encounter mixed-language strings in a file you're editing:
+When you encounter hardcoded or mixed-language strings in a file you're editing:
 
 1. **Identify** user-facing strings (displayed to users in browser)
 2. **Wrap** them with `__()` or `_e()`
@@ -81,15 +81,15 @@ When you encounter mixed-language strings in a file you're editing:
    - Internal error messages not shown to users
    - API responses (unless they're user-facing error messages)
 
-## Constants
+## Text Domain
 
-The theme text domain is defined as:
+The text domain should be defined as a constant in the project's configuration:
 
 ```php
-define('THEME_TEXT_DOMAIN', 'nok-2025-v1');
+define('TEXT_DOMAIN', 'my-theme');
 ```
 
-Always use `THEME_TEXT_DOMAIN` constant, never hardcode the text domain string.
+Always use the text domain constant in PHP. In JavaScript, use the text domain string directly (JS doesn't have access to PHP constants).
 
 ## Generating POT Files
 
@@ -97,10 +97,10 @@ After making i18n changes, regenerate the POT file:
 
 ```bash
 # Using WP-CLI (if available)
-wp i18n make-pot . languages/nok-2025-v1.pot --domain=nok-2025-v1
+wp i18n make-pot . languages/<text-domain>.pot --domain=<text-domain>
 
 # Or using @wordpress/i18n npm package
-npx @wordpress/i18n make-pot . languages/nok-2025-v1.pot
+npx @wordpress/i18n make-pot . languages/<text-domain>.pot
 ```
 
 ## Checklist
@@ -108,13 +108,13 @@ npx @wordpress/i18n make-pot . languages/nok-2025-v1.pot
 When touching files with strings:
 - [ ] User-facing PHP strings wrapped with `__()` or `_e()`
 - [ ] User-facing JS strings use `@wordpress/i18n`
-- [ ] Text domain is `THEME_TEXT_DOMAIN` (PHP) or `'nok-2025-v1'` (JS)
+- [ ] Text domain constant used in PHP, text domain string in JS
 - [ ] Code comments remain in English
-- [ ] No hardcoded Dutch strings without translation wrapper
+- [ ] No hardcoded user-facing strings without translation wrapper
 - [ ] Placeholders use `printf()`/`sprintf()` not concatenation
 
 ## Priority
 
 This is a **low-priority** gradual cleanup task. Don't create separate commits
-just for i18n changes - include them when you're already modifying a file for
+just for i18n changes — include them when you're already modifying a file for
 other reasons.

--- a/js-standards/skill.md
+++ b/js-standards/skill.md
@@ -1,49 +1,21 @@
 # JavaScript Standards and Patterns
 
-Apply when writing or modifying JavaScript in `assets/js/`. Covers DOMule library usage, module patterns, and event handling.
-
-## DOMule Library
-
-External library at `assets/js/domule/`. Repository: https://github.com/c-kick/DOMule
-
-### Core Modules
-
-| Module | Purpose |
-|--------|---------|
-| `core.events.mjs` | Event system with `docReady`, `docLoaded`, `addListener` |
-| `core.loader.mjs` | Dynamic module loading via `data-requires` |
-| `core.log.mjs` | Logging with `logger.info()`, `logger.error()`, `DEBUG` flag |
-
-### Utilities
-
-| Utility | Purpose |
-|---------|---------|
-| `util.ensure-visibility.mjs` | `ViewportScroller` - scroll elements into view with header detection |
-| `util.observe.mjs` | `isVisible`, `isUnobstructed`, `getBlockerHeight` |
-| `util.debounce.mjs` | Debounce/throttle utilities |
-
-### Click Handlers (`modules/hnl.clickhandlers.mjs`)
-
-```js
-import {singleClick, doubleClick} from './domule/modules/hnl.clickhandlers.mjs';
-
-// Bind to elements - uses PointerEvent for unified mouse/touch/pen handling
-singleClick(document.querySelectorAll('.my-button'), (e, element) => {
-    // e.target is the clicked element
-    // element is the bound element (from currentTarget)
-});
-```
+Apply when writing or modifying JavaScript modules. Covers module patterns, event handling, lazy loading, and scroll utilities.
 
 ## Event Handling: Delegation vs Direct Binding
 
-### Direct Binding (`singleClick`)
+### Direct Binding
 
 ```js
-singleClick(document.querySelectorAll('a[href*="#"]'), handler);
+document.querySelectorAll('.my-button').forEach(el => {
+    el.addEventListener('pointerup', (e) => {
+        // handle click/tap/pen
+    });
+});
 ```
 
-**Pros:** Clean syntax, unified pointer handling (mouse/touch/pen)
-**Cons:** Only binds to elements present at DOM ready. Dynamically added elements won't be handled.
+**Pros:** Simple, scoped to known elements, unified pointer handling (mouse/touch/pen) via PointerEvent
+**Cons:** Only binds to elements present at bind time. Dynamically added elements won't be handled.
 
 ### Event Delegation
 
@@ -62,18 +34,16 @@ document.addEventListener('click', (e) => {
 
 | Scenario | Approach |
 |----------|----------|
-| Static elements (nav, footer links) | `singleClick` - cleaner |
+| Static elements (nav, footer links) | Direct binding - cleaner |
 | Dynamic content (AJAX-loaded, SPA) | Event delegation |
 | Global handlers (anchor scrolling) | Event delegation |
-| Component-scoped clicks | `singleClick` |
+| Component-scoped clicks | Direct binding |
 
-## ViewportScroller Pattern
+## Scroll-to-Element Pattern
 
-For scroll-to-anchor functionality, cache ViewportScroller instances in a WeakMap to ensure consistent positioning and prevent rounding drift on repeated scrolls.
+For scroll-to-anchor functionality, cache scroll controller instances in a WeakMap to ensure consistent positioning and prevent rounding drift on repeated scrolls.
 
 ```js
-import {ViewportScroller} from './domule/util.ensure-visibility.mjs';
-
 // WeakMap allows garbage collection when elements are removed
 const scrollerMap = new WeakMap();
 
@@ -82,13 +52,11 @@ const scrollToElement = (el) => {
 
     let scroller = scrollerMap.get(el);
     if (!scroller) {
-        scroller = new ViewportScroller(el, {
-            behavior: 'smooth',
-            extraOffset: 20  // breathing room below header
-        });
+        scroller = { target: el, behavior: 'smooth', extraOffset: 20 };
         scrollerMap.set(el, scroller);
     }
-    scroller.ensureVisible();
+
+    el.scrollIntoView({ behavior: scroller.behavior, block: 'start' });
 };
 ```
 
@@ -98,26 +66,39 @@ const scrollToElement = (el) => {
 
 ## Lazy Loading Modules
 
-Use `data-requires` attribute for lazy-loaded modules:
+Use `data-requires` attributes (or similar) for lazy-loaded modules, combined with IntersectionObserver:
 
 ```html
-<div data-requires="./nok-datepicker.mjs">
+<div data-requires="./datepicker.mjs">
     <!-- Content that needs datepicker -->
 </div>
 ```
 
-The `core.loader.mjs` uses IntersectionObserver to load modules when elements become visible.
+```js
+// Observer triggers module load when element enters viewport
+const observer = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+        if (entry.isIntersecting) {
+            const modulePath = entry.target.dataset.requires;
+            import(modulePath).then(mod => mod.init([entry.target]));
+            observer.unobserve(entry.target);
+        }
+    });
+});
+
+document.querySelectorAll('[data-requires]').forEach(el => observer.observe(el));
+```
 
 ### Module Structure
 
-Modules should export an `init()` function that the loader calls:
+Lazy-loaded modules should export an `init()` function:
 
 ```js
-// nok-my-feature.mjs
+// my-feature.mjs
 export const NAME = 'my-feature';
 
 export function init(elements) {
-    // elements = NodeList of elements that required this module
+    // elements = NodeList/array of elements that required this module
     elements.forEach(el => {
         // Initialize feature on element
     });
@@ -126,26 +107,22 @@ export function init(elements) {
 
 ## Event System
 
-```js
-import events from './domule/core.events.mjs';
+When using a centralized event system, typical lifecycle hooks include:
 
+```js
 // DOM ready (DOMContentLoaded)
-events.docReady(() => {
+document.addEventListener('DOMContentLoaded', () => {
     // DOM is parsed, safe to query elements
 });
 
-// DOM loaded (window load)
-events.docLoaded(() => {
-    // All resources loaded (images, etc.)
+// All resources loaded
+window.addEventListener('load', () => {
+    // All resources loaded (images, fonts, etc.)
 });
 
-// Custom events with cleanup
-events.addListener('scroll', (e) => {
-    // Throttled scroll handler
-});
-
-events.addListener('breakPointChange', (e) => {
-    // Responsive breakpoint changed
+// Custom events for app-level coordination
+window.addEventListener('breakpointchange', (e) => {
+    // Respond to viewport breakpoint changes
 });
 ```
 
@@ -154,23 +131,28 @@ events.addListener('breakPointChange', (e) => {
 Source files use `.mjs` extension. Minified versions are `.min.mjs`:
 
 ```
-nok-feature.mjs      # Source (development)
-nok-feature.min.mjs  # Minified (production)
+my-feature.mjs      # Source (development)
+my-feature.min.mjs   # Minified (production)
 ```
 
-The loader automatically selects minified versions in production.
+The build system or loader should automatically select minified versions in production.
 
 ## Debugging
 
+Use a structured logging approach:
+
 ```js
-import {logger, DEBUG} from './domule/core.log.mjs';
+const DEBUG = new URLSearchParams(location.search).has('debug');
+
+const logger = {
+    info: (module, ...args) => console.info(`[${module}]`, ...args),
+    error: (module, ...args) => console.error(`[${module}]`, ...args),
+    debug: (module, ...args) => { if (DEBUG) console.log(`[${module}]`, ...args); },
+};
 
 logger.info(NAME, 'Starting up...');
 logger.error(NAME, 'Something went wrong', error);
-
-if (DEBUG) {
-    logger.log(NAME, 'Debug-only message');
-}
+logger.debug(NAME, 'Debug-only message');
 ```
 
 `DEBUG` is true when `?debug` is in the URL or in development mode.

--- a/php-documentation-standards/SKILL.md
+++ b/php-documentation-standards/SKILL.md
@@ -118,5 +118,4 @@ Before committing:
 
 ## Complete Standards
 
-For detailed standards with full examples, see:
-@../../docs/php_documentation_standards.md
+If the project has extended documentation standards, check for a dedicated docs file (e.g., `docs/php_documentation_standards.md`) for full examples and project-specific conventions.

--- a/scss-standards/SKILL.md
+++ b/scss-standards/SKILL.md
@@ -4,58 +4,58 @@ Apply when working with CSS, SCSS, or styling in this project.
 
 ## Architecture Overview
 
-**Main entry points (webpack-compiled):**
+A well-structured SCSS project separates concerns into entry points, components, tools, and tokens. Adapt the structure below to match the project's naming conventions.
+
+**Main entry points (compiled via bundler):**
 | File | Output | Purpose |
 |------|--------|---------|
-| `assets/css/nok-components.scss` | `nok-components.css` | Frontend styles |
-| `assets/css/nok-backend-css.scss` | `nok-backend-css.css` | Admin/editor |
-| `assets/css/color_tests-v2.scss` | `color_tests-v2.css` | Color system |
+| `assets/css/components.scss` | `components.css` | Frontend styles |
+| `assets/css/backend.scss` | `backend.css` | Admin/editor styles |
 
-**Directory structure:**
+**Recommended directory structure:**
 ```
 assets/css/
-├── components/          # Production BEM components (_nok-*.scss)
-├── tools/               # Mixins, RFS, utilities
-├── libs/                # Third-party (baseline grid)
-├── _nok-variables.scss  # Design tokens, breakpoints
-├── _nok-colors-v2.scss  # OKLCH color system
-├── _nok-helpers.scss    # Utility classes (loaded last)
-└── _nok-reboot.scss     # CSS reset
+├── components/          # BEM components (_*.scss)
+├── tools/               # Mixins, utilities, RFS
+├── libs/                # Third-party styles
+├── _variables.scss      # Design tokens, breakpoints
+├── _colors.scss         # Color system
+├── _helpers.scss        # Utility classes (loaded last)
+└── _reboot.scss         # CSS reset / normalization
 ```
 
 ## Build Commands
 
 ```bash
-# Main build (webpack)
+# Main build (via bundler)
 npm run build
 
-# Compile individual post-part CSS (sass CLI)
-npx sass template-parts/post-parts/{name}.scss template-parts/post-parts/{name}.css
+# Compile individual standalone SCSS files (sass CLI)
+npx sass path/to/{name}.scss path/to/{name}.css
 
 # Minified version
-npx sass template-parts/post-parts/{name}.scss template-parts/post-parts/{name}.min.css --style=compressed
+npx sass path/to/{name}.scss path/to/{name}.min.css --style=compressed
 ```
 
-## Post-Parts CSS (Lazy-loaded)
+## Standalone Component CSS (Lazy-loaded)
 
-Post-parts with custom styles have co-located SCSS files that compile separately:
-- `template-parts/post-parts/nok-bmi-calculator.scss` → `.css`
-- These are **not** in webpack — compile manually with `npx sass`
-- `TemplateRenderer.php` loads CSS via `resolve_css_file()` method
+Components with custom styles can have co-located SCSS files that compile separately from the main bundle:
+- These are **not** in the bundler — compile manually with `npx sass`
+- The template system should load these CSS files on demand when the component is rendered
 
 ## Module System
 
 Use `@use` with namespacing (not deprecated `@import`):
 ```scss
 @use "shared" as components-base;
-@use "../tools/nok-mixins" as mixins;
+@use "../tools/mixins" as mixins;
 
 // Access via namespace
 @include components-base.transition-properties { ... }
 @include mixins.media-breakpoint-down(md) { ... }
 ```
 
-**Exception:** `_nok-helpers.scss` uses `@import` in `nok-components.scss` to ensure it cascades last for utility overrides.
+**Exception:** Helper/utility files may use `@import` in the main entry point to ensure they cascade last for utility overrides.
 
 ## Performance Patterns
 
@@ -84,13 +84,13 @@ transition: backdrop-filter 300ms ease;
 
 ## Color System
 
-Uses OKLCH color space via `_nok-colors-v2.scss`:
+Use CSS custom properties for the color system. OKLCH is recommended for perceptual uniformity:
 ```scss
 // Colors exposed as CSS custom properties
---nok-lightblue, --nok-darkblue, --nok-yellow, etc.
+--color-primary, --color-secondary, --color-accent, etc.
 
 // With variants
---nok-lightblue--darker, --nok-lightblue--lighter
+--color-primary--darker, --color-primary--lighter
 
 // Alpha control via CSS variable
 --bg-alpha-value: 0.5;
@@ -98,14 +98,14 @@ Uses OKLCH color space via `_nok-colors-v2.scss`:
 
 ## Common Mixins
 
-From `tools/_nok-mixins.scss`:
+Provide project mixins for responsive breakpoints, typography, and component patterns:
 ```scss
 @include mixins.media-breakpoint-down(md) { }
 @include mixins.media-breakpoint-up(lg) { }
-@include mixins.nok-border-radius('large', 'bottom');
+@include mixins.border-radius('large', 'bottom');
 @include mixins.transition-properties { }
-@include mixins.nok-text-font;
-@include mixins.nok-heading-font;
+@include mixins.text-font;
+@include mixins.heading-font;
 ```
 
 ## Breakpoints


### PR DESCRIPTION
- scss-standards: Replace all nok-* prefixed file names, CSS custom properties, and mixin names with generic equivalents. Remove project-specific paths (template-parts/post-parts/, TemplateRenderer.php).
- js-standards: Remove DOMule library dependency and c-kick/DOMule repo reference. Replace with equivalent vanilla JS patterns (IntersectionObserver for lazy loading, native scrollIntoView, structured logger). Keep all patterns functional with self-contained examples.
- i18n-standards: Replace hardcoded text domain 'nok-2025-v1' and THEME_TEXT_DOMAIN with generic TEXT_DOMAIN / 'my-theme' placeholders. Remove project-specific language context. Generalize POT file commands.
- php-documentation-standards: Replace hardcoded relative path reference with generic guidance.

https://claude.ai/code/session_01NS8SJv6Z83s7g3iEYZ5VSE